### PR TITLE
refactor: move files to `misc/cloudflare-workers`

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,21 +18,12 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
-          <a
-            href="https://github.com/hi-ogawa/remix-vite-deployment-examples"
-            target="_blank"
-          >
-            Source code
-          </a>
-          <span
-            ref={(el) => {
-              if (el) el.textContent = "hydrated";
-            }}
-            style={{ opacity: 0.5 }}
-          >
-          </span>
-        </div>
+        <a
+          href="https://github.com/hi-ogawa/remix-vite-deployment-examples"
+          target="_blank"
+        >
+          Source code
+        </a>
         <ul>
           <li>
             <Link to="/">root</Link>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,12 +18,21 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <a
-          href="https://github.com/hi-ogawa/remix-vite-deployment-examples"
-          target="_blank"
-        >
-          Source code
-        </a>
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <a
+            href="https://github.com/hi-ogawa/remix-vite-deployment-examples"
+            target="_blank"
+          >
+            Source code
+          </a>
+          <span
+            ref={(el) => {
+              if (el) el.textContent = "hydrated";
+            }}
+            style={{ opacity: 0.5 }}
+          >
+          </span>
+        </div>
         <ul>
           <li>
             <Link to="/">root</Link>

--- a/misc/cloudflare-workers/README.md
+++ b/misc/cloudflare-workers/README.md
@@ -1,0 +1,3 @@
+# cloudflare-workers
+
+scripts for Cloudflare Workers deployment

--- a/misc/cloudflare-workers/wrangler.toml
+++ b/misc/cloudflare-workers/wrangler.toml
@@ -1,7 +1,7 @@
 name = "remix-vite-deploy"
 
-main = "./app/adapters/cloudflare-workers.ts"
-assets = "./build/client"
+main = "../../app/adapters/cloudflare-workers.ts"
+assets = "../../build/client"
 workers_dev = true
 compatibility_date = "2023-04-20"
 minify = true

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && vite build --ssr",
-    "preview-cloudflare-workers": "wrangler dev",
-    "release-cloudflare-workers": "wrangler deploy",
+    "preview-cloudflare-workers": "cd misc/cloudflare-workers && wrangler dev",
+    "release-cloudflare-workers": "cd misc/cloudflare-workers && wrangler deploy",
     "build-vercel-edge": "bash misc/vercel-edge/build.sh",
     "release-vercel-edge": "vercel deploy --prebuilt misc/vercel-edge --prod",
     "build-vercel-serverless": "bash misc/vercel-serverless/build.sh",


### PR DESCRIPTION
It looks like Cloudflare pages are too coupled with file structure (or git? node_modules?) and it behaves odd when trying to do something in a sub directory.
In order to let cloudflare pages operate on root project, let's move cloudflare workers under the sub directory, which is more flexibile.