### PR TITLE
chore: use `@hattip/adapter-node/native-fetch`

### DIFF
--- a/app/adapters/vercel-serverless.ts
+++ b/app/adapters/vercel-serverless.ts
@@ -1,4 +1,4 @@
-import { createMiddleware } from "@hattip/adapter-node";
+import { createMiddleware } from "@hattip/adapter-node/native-fetch";
 import { remixHandler } from "./base";
 
 export default createMiddleware((ctx) => remixHandler(ctx.request));

--- a/misc/vercel-serverless/build.sh
+++ b/misc/vercel-serverless/build.sh
@@ -29,7 +29,6 @@ rm -rf .vercel/output/static/.vite
 mkdir -p .vercel/output/functions/index.func
 cp .vc-config.json .vercel/output/functions/index.func/.vc-config.json
 
-# TODO: exclude unnecessary hattip node-fetch-native polyfills?
 npx esbuild ../../app/adapters/vercel-serverless.ts \
   --outfile=.vercel/output/functions/index.func/index.mjs \
   --metafile=../../build/esbuild-metafile-vercel-serverless.json \


### PR DESCRIPTION
Just found out hattip already provides non-polyfill version of adapter. Awesome!

<details><summary>before</summary>

![image](https://github.com/hi-ogawa/remix-vite-deployment-examples/assets/4232207/5eb7c117-dbce-4231-9432-d1a758566471)

</details>

<details><summary>after</summary>

![image](https://github.com/hi-ogawa/remix-vite-deployment-examples/assets/4232207/9198556d-3b16-4448-b386-e2f58108095f)

</details>