### PR TITLE
refactor: use cloudflare pages "advanced mode" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules
 build
 .wrangler
 .vercel
-functions

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,3 @@ node_modules
 build
 .wrangler
 .vercel
-functions

--- a/app/adapters/cloudflare-pages.ts
+++ b/app/adapters/cloudflare-pages.ts
@@ -1,5 +1,0 @@
-import { remixHandler } from "./base.js";
-
-export function onRequest(ctx: { request: Request }) {
-  return remixHandler(ctx.request);
-}

--- a/misc/cloudflare-pages/build.sh
+++ b/misc/cloudflare-pages/build.sh
@@ -6,13 +6,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # static
 mkdir -p build/client
 cp -r ../../build/client/. build/client
-rm -rf .vercel/output/static/.vite
+rm -rf build/client/.vite
 cp _headers _routes.json build/client
 
-# functions
-mkdir -p "functions"
-rm -f "../../functions/[[path]].js"
-npx esbuild ../../app/adapters/cloudflare-pages.ts \
-  "--outfile=../../functions/[[path]].js" \
+# functions (advanced mode https://developers.cloudflare.com/pages/platform/functions/advanced-mode/)
+npx esbuild ../../app/adapters/cloudflare-workers.ts \
+  "--outfile=build/client/_worker.js" \
   --metafile=build/esbuild-metafile-cloudflare-pages.json \
   --bundle --minify --format=esm --platform=browser


### PR DESCRIPTION
This would cut-off rather redundant abstraction of cloudflare pages https://developers.cloudflare.com/pages/platform/functions/advanced-mode/
I noticed that this "Advanced mode" is also used by sveltekit https://github.com/sveltejs/kit/blob/3d98c37c09aa53d1bf8e5dcf12aef62a43afcae8/packages/adapter-cloudflare/index.js#L41

See also https://github.com/remix-run/remix/discussions/8138#discussioncomment-7748039